### PR TITLE
Fixed controller, pause menu bug and tweaked Pam behavior

### DIFF
--- a/BusLocations/manifest.json
+++ b/BusLocations/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Bus Locations",
   "Author": "nanzington",
-  "Version": "1.3",
+  "Version": "1.3.1",
   "Description": "A framework that lets modders dynamically add new locations for the bus to go to.",
   "UniqueID": "hootless.BusLocations",
   "EntryDll": "BusLocations.dll",


### PR DESCRIPTION
So I made these changes mostly to fix an annoying issue I had playing with controller for so long, if you selected something from the menu then the menu would appear again and again so I added a check to see if the player canMove (since menu is open then player would not be able to move, this prevents menu action from triggering over and over). While fixing this I noticed you could open the bus menu even when pause menu or inventory was open, so I added another conditional.

And another thing I did was changing the pam behavior cause I noticed you could use the Bus anytime, anyday. Now it will correctly check is Pam is on the bus but if there is a passive festival happening or Pam is in the hospital then you can ride the bus.

Note: there is currently another bug I was not able to find a solution but I think it has to do with overlapping actions, if you move while clicking the bus machine, sometimes the vanilla "want to buy a ticket to calico?" menu would appear instead of the modded one. This is very random and not very common but can happen, just close menu and click again while standing still to prevent it.